### PR TITLE
Add support for Llama2, Palm, Cohere, Anthropic, Replicate, Azure Models - using litellm

### DIFF
--- a/code/openai_dialog_quality_evaluation.py
+++ b/code/openai_dialog_quality_evaluation.py
@@ -12,7 +12,7 @@ os.environ["OPENAI_API_KEY"] = ""
 
 from langchain.chains.llm import LLMChain
 from langchain.prompts import PromptTemplate
-from langchain.chat_models import ChatOpenAI
+from langchain.chat_models import ChatOpenAI, ChatLiteLLM
 import json
 from utils import open_json, save_json, open_jsonl
 from collections import defaultdict
@@ -54,7 +54,7 @@ class EvaluateDialogs(object):
             """
         )
 
-        self.quality_chain = LLMChain(llm=ChatOpenAI(temperature=0.2, model_name="gpt-3.5-turbo"), prompt=self.quality_agent_prompt)
+        self.quality_chain = LLMChain(llm=ChatLiteLLM(temperature=0.2, model_name="gpt-3.5-turbo"), prompt=self.quality_agent_prompt)
 
     def run_openai_evaluation(self, dialog):
         res = self.quality_chain.run(dialog=dialog)


### PR DESCRIPTION
This PR adds support for 50+ models using liteLLM : https://github.com/BerriAI/litellm/

`ChatLiteLLM()` is integrated into langchain and allows you to call all models using the ChatOpenAI I/O interface 
https://python.langchain.com/docs/integrations/chat/litellm

Here's an example of how to use ChatLiteLLM()
```python
ChatLiteLLM(model="gpt-3.5-turbo")
ChatLiteLLM(model="claude-2", temperature=0.3)
ChatLiteLLM(model="command-nightly")
ChatLiteLLM(model="replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1")

```